### PR TITLE
Update image_one.yml

### DIFF
--- a/.github/workflows/image_one.yml
+++ b/.github/workflows/image_one.yml
@@ -65,7 +65,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: src/${{ inputs.dockerfile_name }}
           context: src
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Added support for arm64
我自己的arm机器拉带jdk和py的额外镜像会提示没有manifest，我看主仓库有对arm64的支持，因此在此仓库也加上了，作者可以看下是否需要